### PR TITLE
Relativepath2

### DIFF
--- a/src/laser/ddg/ProvenanceData.java
+++ b/src/laser/ddg/ProvenanceData.java
@@ -756,6 +756,12 @@ public class ProvenanceData {
 	public void setSourceDDGFile(String sourceDDGFile) {
 		this.sourceDDGFile = sourceDDGFile;
 		attributes.set("souceDDGFile", sourceDDGFile);
+
+	}
+
+	public File getSourceDDGDirectory(){
+		File thefile = new File(sourceDDGFile);
+		return thefile.getParentFile();
 	}
 	
 	public void addAttribute(String name, String value) {

--- a/src/laser/ddg/persist/Parser.java
+++ b/src/laser/ddg/persist/Parser.java
@@ -667,6 +667,9 @@ public class Parser {
 					if (value == null) {
 						value = parseValue(nodeId);
 						if (value != null) {
+							File thefile = new File(value);
+							File relative = new File(builder.getSourceDDGDirectory(), thefile.getName());
+							value = relative.getAbsolutePath();
 							somethingMatched = true;
 						}
 					}

--- a/src/laser/ddg/visualizer/PrefuseGraphBuilder.java
+++ b/src/laser/ddg/visualizer/PrefuseGraphBuilder.java
@@ -2070,6 +2070,10 @@ public class PrefuseGraphBuilder implements ProvenanceListener, ProvenanceDataVi
 		return vis.getFinish((Node) collapsedNode);
 	}
 
+	public File getSourceDDGDirectory(){
+		return provData.getSourceDDGDirectory();
+	}
+
 
 
 }


### PR DESCRIPTION
This, with the changes in branch RDataTracker in relativepaths, allows the DDG-Explorer to read from ddg.txt and database no matter where the file is stored, as it changes file directories according to where the file is loaded from.