### PR TITLE
Allow to choose between default (aka cross platform) and system specific look and feel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ manifest.mf
 lib/nblibraries.properties
 nbbuild.xml
 *.jar
+/dist/

--- a/build.xml
+++ b/build.xml
@@ -24,7 +24,6 @@
         <pathelement location="lib/xml-apis-1.4.01.jar"/>
         <pathelement location="lib/CPL.jar"/>
         <pathelement location="lib/jdiff.jar"/>
-		<pathelement location="lib/weblaf-complete-1.29.jar"/>
     </path>
     <target name="init">
         <mkdir dir="bin"/>
@@ -109,9 +108,6 @@
   		
   		<!-- Code to support text file differences -->
   		<zipfileset includes="**/*" src="lib/jdiff.jar" />
-		
-		<!-- Look and feel -->
-		<zipfileset includes="**/*" src="lib/weblaf-complete-1.29.jar"/>
    	</jar>
   	<move file="tmp_ddg-explorer.jar" tofile="ddg-explorer_${version}.jar"/>
     <chmod file="ddg-explorer_${version}.jar" perm="755"/>

--- a/src/laser/ddg/commands/SystemLookAndFeelCommand.java
+++ b/src/laser/ddg/commands/SystemLookAndFeelCommand.java
@@ -1,0 +1,39 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package laser.ddg.commands;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.JCheckBoxMenuItem;
+import laser.ddg.gui.DDGExplorer;
+
+/**
+ *  Command to control the look and feel.
+ * 
+ * @author Thomas Pasquier
+ * @version 01/07/2016
+ */
+public class SystemLookAndFeelCommand implements ActionListener {
+    /**
+	 * Sets whether line numbers are shown based on the setting of the
+	 * corresponding menu item.
+         * @param e
+	 */
+	@Override
+	public void actionPerformed(ActionEvent e) {
+		useSystemLookAndFeel((JCheckBoxMenuItem) e.getSource());
+	}
+        
+        /**
+	 * Sets whether to use default or system look and feel.
+	 * 
+         * @param systemLookAndFeelMenuItem
+	 */
+	public static void useSystemLookAndFeel(final JCheckBoxMenuItem systemLookAndFeelMenuItem) {
+		DDGExplorer ddgExplorer = DDGExplorer.getInstance();
+		ddgExplorer.useSystemLookAndFeel(systemLookAndFeelMenuItem.isSelected());
+	}
+}

--- a/src/laser/ddg/gui/DDGExplorer.java
+++ b/src/laser/ddg/gui/DDGExplorer.java
@@ -1,6 +1,5 @@
 package laser.ddg.gui;
 
-import com.alee.laf.WebLookAndFeel;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -19,6 +18,7 @@ import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.event.ChangeEvent;
@@ -42,6 +42,7 @@ import laser.ddg.commands.ShowLegendMenuItem;
 import laser.ddg.commands.ShowLineNumbersCommand;
 import laser.ddg.commands.ShowScriptCommand;
 import laser.ddg.commands.ShowValueDerivationCommand;
+import laser.ddg.commands.SystemLookAndFeelCommand;
 import laser.ddg.query.DerivationQuery;
 import laser.ddg.query.Query;
 import laser.ddg.query.QueryListener;
@@ -156,6 +157,24 @@ public class DDGExplorer extends JFrame implements QueryListener {
 		setLocationRelativeTo(null);
 		setVisible(true);
 	}
+        
+        /**
+        * Load look and feel based on user preference.
+        * @param system
+        */
+        public void loadLookAndFeel(boolean system) {
+            try{
+                String lookAndFeel;
+                if(system) {
+                    lookAndFeel = UIManager.getSystemLookAndFeelClassName();                    
+                }else{
+                    lookAndFeel = UIManager.getCrossPlatformLookAndFeelClassName();
+                }
+                UIManager.setLookAndFeel( lookAndFeel );
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | UnsupportedLookAndFeelException e) {
+                e.printStackTrace(System.err);
+            }
+        }
 
 	private JTabbedPane createTabbedPane() {
 		JTabbedPane tabbedPane = new JTabbedPane() {
@@ -356,10 +375,10 @@ public class DDGExplorer extends JFrame implements QueryListener {
 		JMenu prefMenu = new JMenu("Preferences");
 		prefMenu.setBackground(MENU_COLOR);
 		
-		final JCheckBoxMenuItem inToOutMenuItem = new JCheckBoxMenuItem("Draw arrows from inputs to outputs", 
+		final JCheckBoxMenuItem arrowsDirectionMenuItem = new JCheckBoxMenuItem("Draw arrows from inputs to outputs", 
 				preferences.isArrowDirectionDown());
-		inToOutMenuItem.addActionListener(new SetArrowDirectionCommand());
-		prefMenu.add(inToOutMenuItem);
+		arrowsDirectionMenuItem.addActionListener(new SetArrowDirectionCommand());
+		prefMenu.add(arrowsDirectionMenuItem);
 		
 		showLegendMenuItem = new JCheckBoxMenuItem("Show legend", 
 				preferences.isShowLegend());
@@ -371,8 +390,10 @@ public class DDGExplorer extends JFrame implements QueryListener {
 		showLineNumbersMenuItem.addActionListener(new ShowLineNumbersCommand());
 		prefMenu.add(showLineNumbersMenuItem);
 		
-		
-		
+		final JCheckBoxMenuItem useSystemLAFMenuItem = new JCheckBoxMenuItem("Use system Look and Feel", 
+				preferences.isSystemLookAnFeel());
+		useSystemLAFMenuItem.addActionListener(new SystemLookAndFeelCommand());
+                prefMenu.add(useSystemLAFMenuItem);
 		return prefMenu;
 	}
 
@@ -466,6 +487,12 @@ public class DDGExplorer extends JFrame implements QueryListener {
 		}
 		preferences.showLineNumbers(show);
 	}
+        
+        public void useSystemLookAndFeel(boolean use){
+            loadLookAndFeel(use);
+            SwingUtilities.updateComponentTreeUI(this);
+            preferences.useSystemLookAndFeel(use);
+        }
 
 	/**
 	 * Show the legend.  Change the user's preferences to always show
@@ -519,18 +546,12 @@ public class DDGExplorer extends JFrame implements QueryListener {
 	 * 
 	 * @param args
 	 */
-	public static void main(String[] args) {
-                try{
-                    UIManager.setLookAndFeel( new WebLookAndFeel() );
-                } catch (UnsupportedLookAndFeelException e) {
-                    e.printStackTrace(System.err);
-                }
-            
+	public static void main(String[] args) {            
 		try {
 			DDGExplorer explorer = DDGExplorer.getInstance();
 			preferences.load();
+                        explorer.loadLookAndFeel(preferences.isSystemLookAnFeel());
 			explorer.createAndShowGUI();
-
 		} catch (Exception e) {
 			JOptionPane.showMessageDialog(null,
 					"Unable to start DDG Explorer: " + e.getMessage(),

--- a/src/laser/ddg/gui/Preferences.java
+++ b/src/laser/ddg/gui/Preferences.java
@@ -191,6 +191,28 @@ public class Preferences {
 		savePreferences();
 	}
 
-
-
+        /**
+        * Determine from preference if default or system LAF should be used. 
+        * @return true if system LAF should be used, false by default.
+        */
+        public boolean isSystemLookAnFeel() {
+            if (preferences.containsKey("SystemLookAnFeel")) {
+                    return preferences.get("SystemLookAnFeel").toLowerCase().equals("true");
+            }
+            return false;
+        }
+        
+        /**
+        * Set either to use the default LAF (false) or the system one (true)
+        * @param use true for system LAF, false set to default.
+        */
+        public void useSystemLookAndFeel(boolean use){
+            if (use) {
+                    preferences.put("SystemLookAnFeel", "true");
+            }
+            else {
+                    preferences.put("SystemLookAnFeel", "false");
+            }
+            savePreferences();
+        }
 }


### PR DESCRIPTION
The changes add:
- an option in the preference menu;
- reading/writing in preference file;
- change LAF at runtime between cross platform and platform specific LAF (load at boot whatever is set in the preference file);
- LAF is by default the cross platform one;
- renamed inToOutMenuItem variable to arrowsDirectionMenuItem for better code readability.

I don't have a MAC so could not test there, please let me know how it looks there (or if any problem on that specific platform), and if it changes the default LAF (hopefully behaviour is standard across platform so crossplatform LAF should be default as well, but you never know).

We can add more options later.

Screenshot of the different LAF:
![default-ubuntu](https://cloud.githubusercontent.com/assets/1970355/16520176/62a894aa-3f5c-11e6-9e10-762723c8dfbf.png)
![system-ubuntu](https://cloud.githubusercontent.com/assets/1970355/16520178/6552950c-3f5c-11e6-98b6-1f29fa4dcb46.png)
![default-windows](https://cloud.githubusercontent.com/assets/1970355/16520180/66d1fdc8-3f5c-11e6-997b-83544533d89c.png)
![system-windows](https://cloud.githubusercontent.com/assets/1970355/16520181/68efa10a-3f5c-11e6-8018-eef88a95bb51.png)
