### PR TITLE
Make file nodes always visible.

### DIFF
--- a/src/laser/ddg/visualizer/PrefuseGraphBuilder.java
+++ b/src/laser/ddg/visualizer/PrefuseGraphBuilder.java
@@ -1275,6 +1275,12 @@ public class PrefuseGraphBuilder implements ProvenanceListener, ProvenanceDataVi
 		while (outNeighbors.hasNext()) {
 			Set<Node> edgesAddedTo = new HashSet<>();
 			Node neighbor = outNeighbors.next();
+			
+			// If it is a file, always add the edge
+			if (PrefuseUtils.isFile((NodeItem)neighbor) && !PrefuseUtils.isSnapshot((NodeItem)neighbor)) {
+				addEdge(PrefuseUtils.STEPDF, collapsedNodeId, PrefuseUtils.getId(neighbor));
+				edgesAddedTo.add(neighbor);
+			}
 
 			// Check if it is a data node
 			if (PrefuseUtils.isAnyDataNode(neighbor)) {
@@ -1318,9 +1324,15 @@ public class PrefuseGraphBuilder implements ProvenanceListener, ProvenanceDataVi
 		Iterator<Node> inNeighbors = member.inNeighbors();
 		while (inNeighbors.hasNext()) {
 			Node neighbor = inNeighbors.next();
+			
+			// If the edge comes from a file node, always add the edge
+			if (PrefuseUtils.isFile((NodeItem)neighbor) && !PrefuseUtils.isSnapshot((NodeItem)neighbor)) {
+				addEdge(PrefuseUtils.STEPDF, PrefuseUtils.getId(neighbor), collapsedNodeId);
+				edgesAddedFrom.add(neighbor);
+			}
 
 			// Check that the edge comes from a data node
-			if (PrefuseUtils.isAnyDataNode(neighbor)) {
+			else if (PrefuseUtils.isAnyDataNode(neighbor)) {
 				Iterator<Node> dataConsumers = neighbor.inNeighbors();
 
 				// Find the consumers of the data node
@@ -1735,6 +1747,12 @@ public class PrefuseGraphBuilder implements ProvenanceListener, ProvenanceDataVi
 	 *            node.
 	 */
 	private static void setDataNodeVisibility(NodeItem node) {
+		// Always make files visible
+		if (PrefuseUtils.isFile(node) && !PrefuseUtils.isSnapshot(node)) {
+			node.setVisible (true);
+			return;
+		}
+		
 		// Find the producer and the consumers of the data node
 		Iterator<NodeItem> dataNeighbors = node.neighbors();
 		boolean visible = false;

--- a/src/laser/ddg/visualizer/PrefuseUtils.java
+++ b/src/laser/ddg/visualizer/PrefuseUtils.java
@@ -469,6 +469,11 @@ public class PrefuseUtils {
 		return nodeType.equals(FILE) || nodeType.equals(SNAPSHOT);
 	}
 
+	public static boolean isSnapshot(VisualItem node) {
+		String nodeType = node.getString(TYPE);
+		return nodeType.equals(SNAPSHOT);
+	}
+
 	private static String getNodeType(Node n) {
 		return n.getString(PrefuseUtils.TYPE);
 	}


### PR DESCRIPTION
Makes it easy for the user to see what files are input and output by the
script.