### PR TITLE
Handles attempt to display rds files

### DIFF
--- a/src/laser/ddg/visualizer/BinaryFileException.java
+++ b/src/laser/ddg/visualizer/BinaryFileException.java
@@ -1,0 +1,27 @@
+package laser.ddg.visualizer;
+
+import java.io.IOException;
+
+/**
+ * An exception used to indicate an attempt to display the contents of a binary file.
+ * 
+ * @author Barbara Lerner
+ * @version Jun 12, 2018
+ *
+ */
+public class BinaryFileException extends IOException {
+	/**
+	 * Creates an instance of the exception.
+	 */
+	public BinaryFileException () {
+		super();
+	}
+
+	/**
+	 * Creates an instance of the exception
+	 * @param msg the message to attach to the exception
+	 */
+	public BinaryFileException (String msg) {
+		super(msg);
+	}
+}

--- a/src/laser/ddg/visualizer/DDGDisplay.java
+++ b/src/laser/ddg/visualizer/DDGDisplay.java
@@ -551,9 +551,13 @@ public class DDGDisplay extends Display {
 				else if (PrefuseUtils.isFile(node)) {
 					try {
 						openFile((NodeItem) node);
+			    	} catch (BinaryFileException e1) {
+			    		JOptionPane.showMessageDialog(DDGExplorer.getInstance(), 
+								"Could not load the binary file copied from " + 
+								 PrefuseUtils.getLocation((NodeItem) node));
 					} catch (IOException e1) {
 						JOptionPane.showMessageDialog(DDGExplorer.getInstance(), 
-								"Could not find the file " + PrefuseUtils.getValue((NodeItem) node));
+								"Could not display the file " + PrefuseUtils.getValue((NodeItem) node));
 					}
 
 				}

--- a/src/laser/ddg/visualizer/FileViewer.java
+++ b/src/laser/ddg/visualizer/FileViewer.java
@@ -109,6 +109,9 @@ public class FileViewer {
 		else if (path.endsWith(".htm") || path.endsWith(".html") || path.startsWith("http")){
 			// Nothing to do.  Will launch browser
 		}
+		else if (path.endsWith(".rds")) {
+			throw (new BinaryFileException ());
+		}
 		else { // pdf or any other type of file
 			// Nothing to do.  Will try to launch a platform application  
 		}


### PR DESCRIPTION
An rds file is a serialized R object.  If the user attempts to look at
the value of the node, there will be a message indicating that it is a
binary file and where it was copied from.